### PR TITLE
Obtención todas las pruebas físicas

### DIFF
--- a/basketball/services/prueba_fisica_service.py
+++ b/basketball/services/prueba_fisica_service.py
@@ -107,7 +107,7 @@ class PruebaFisicaService:
 
     def _get_filtered_queryset(self, user):
         """Retorna el queryset de pruebas físicas filtrado por permisos del usuario."""
-        queryset = self.dao.get_by_filter(estado=True).select_related("atleta")
+        queryset = self.dao.get_all().select_related("atleta")
 
         if not user or not hasattr(user, "role"):
             return queryset.none()


### PR DESCRIPTION
Actualiza `_get_filtered_queryset` para recuperar todas las pruebas físicas, independientemente de su estado.

Esto garantiza que el método devuelva todas las pruebas físicas, en lugar de solo aquellas con un estado específico.
